### PR TITLE
FIX: Failed to execute 'encrypt' on 'SubtleCrypto': AesCtrParams: counter: Missing required property

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,7 @@
+// prettier.config.js or .prettierrc.js
+module.exports = {
+    trailingComma: "es5",
+    tabWidth: 4,
+    semi: true,
+    singleQuote: true,
+  };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "@futuretense/secret-box",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/node": {
+      "version": "12.12.47",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.47.tgz",
+      "integrity": "sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^12.12.30",
+    "@types/node": "^12.12.47",
     "ava": "^3.5.0",
     "ava-ts": "^0.25.2",
     "ts-node": "^8.6.2",

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,4 +1,3 @@
-
 export async function encrypt(
     input: Uint8Array,
     key: Uint8Array,
@@ -17,10 +16,23 @@ export async function decrypt(
     return common('decrypt', input, key, nonce, authenticate);
 }
 
-async function common(op, input, key, nonce, authenticate): Promise<Uint8Array> {
+async function common(
+    op: 'encrypt' | 'decrypt',
+    input: Uint8Array,
+    key: DataView | ArrayBuffer,
+    nonce: Uint8Array | null,
+    authenticate: Boolean
+): Promise<Uint8Array> {
     const iv = nonce ? nonce : new Uint8Array(authenticate ? 12 : 16);
     const name = authenticate ? 'AES-GCM' : 'AES-CTR';
-    const k = await window.crypto.subtle.importKey('raw', key, name, false, ['decrypt', 'encrypt']);
-    const output = await window.crypto.subtle[op]({name, iv}, k, input);
+    const k = await window.crypto.subtle.importKey('raw', key, name, false, [
+        'decrypt',
+        'encrypt',
+    ]);
+    const output = await window.crypto.subtle[op](
+        { name, counter: iv, length: authenticate ? 12 : 16 },
+        k,
+        input
+    );
     return new Uint8Array(output);
 }


### PR DESCRIPTION
Fixes error in Browser code that caused exception `Failed to execute 'encrypt' on 'SubtleCrypto': AesCtrParams: counter: Missing required property`.

The issue was here:
```typescript
    const output = await window.crypto.subtle[op]({name, iv /* AES-CRT require conter and length properties, not iv */}, k, input);
```
source: https://github.com/diafygi/webcrypto-examples#aes-ctr---encrypt

Additionally add .prettierrc.js for easier contribution.
